### PR TITLE
[AD-202827] DSS Collections failures (previously released 15/10)

### DIFF
--- a/NCC.DSS.Collections.Tests/Services/PostCollectionHttpTrigger/PostCollectionHttpTriggerServiceTests.cs
+++ b/NCC.DSS.Collections.Tests/Services/PostCollectionHttpTrigger/PostCollectionHttpTriggerServiceTests.cs
@@ -3,10 +3,10 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
+using NCS.DSS.Collections.Cosmos.Helper;
 using NCS.DSS.Collections.Helpers;
 using NCS.DSS.Collections.Models;
 using NCS.DSS.Collections.PostCollectionHttpTrigger.Service;
-using NCS.DSS.Collections.Validators;
 using NUnit.Framework;
 using System;
 using System.Net;
@@ -25,11 +25,8 @@ namespace NCC.DSS.Collections.Tests.Services.PostCollectionHttpTrigger
         private Mock<IPostCollectionHttpTriggerService> _postCollectionHttpTriggerService;
         private Mock<ILogger<PostCollectionHttpLogger.PostCollectionHttpTrigger>> _loggerHelper;
         private Mock<IHttpRequestHelper> _httpRequestHelper;
-        private IHttpResponseMessageHelper _httpResponseMessageHelper;
+        private Mock<IDynamicHelper> _dynamicHelper;
         private Collection _collection;
-        private Mock<IDssCorrelationValidator> _dssCorrelationValidator;
-        private Mock<IDssTouchpointValidator> _dssTouchpointValidator;
-        private Mock<IApimUrlValidator> _apimValidator;
         private PostCollectionHttpLogger.PostCollectionHttpTrigger function;
         private Mock<IDataCollectionsReportHelper> _dataCollectionsReportHelper;
 
@@ -44,14 +41,11 @@ namespace NCC.DSS.Collections.Tests.Services.PostCollectionHttpTrigger
 
             _loggerHelper = new Mock<ILogger<PostCollectionHttpLogger.PostCollectionHttpTrigger>>();
             _httpRequestHelper = new Mock<IHttpRequestHelper>();
-
-            _dssCorrelationValidator = new Mock<IDssCorrelationValidator>();
-            _dssTouchpointValidator = new Mock<IDssTouchpointValidator>();
-            _apimValidator = new Mock<IApimUrlValidator>();
+            _dynamicHelper = new Mock<IDynamicHelper>();
 
             _postCollectionHttpTriggerService = new Mock<IPostCollectionHttpTriggerService>();
 
-            function = new PostCollectionHttpLogger.PostCollectionHttpTrigger(_postCollectionHttpTriggerService.Object, _loggerHelper.Object, _dssCorrelationValidator.Object, _dssTouchpointValidator.Object, _apimValidator.Object, _httpRequestHelper.Object);
+            function = new PostCollectionHttpLogger.PostCollectionHttpTrigger(_postCollectionHttpTriggerService.Object, _loggerHelper.Object, _httpRequestHelper.Object, _dynamicHelper.Object);
         }
 
         [Test]

--- a/NCS.DSS.Collections/Cosmos/Helper/DynamicHelper.cs
+++ b/NCS.DSS.Collections/Cosmos/Helper/DynamicHelper.cs
@@ -1,0 +1,29 @@
+﻿using System.Dynamic;
+
+namespace NCS.DSS.Collections.Cosmos.Helper
+{
+    public class DynamicHelper : IDynamicHelper
+    {
+        public ExpandoObject ExcludeProperty(Exception exception, string[] names)
+        {
+            dynamic updatedObject = new ExpandoObject();
+            foreach (var item in typeof(Exception).GetProperties())
+            {
+                if (names.Contains(item.Name))
+                    continue;
+
+                AddProperty(updatedObject, item.Name, item.GetValue(exception));
+            }
+            return updatedObject;
+        }
+
+        public void AddProperty(ExpandoObject expando, string propertyName, object propertyValue)
+        {
+            var expandoDict = expando as IDictionary<string, object>;
+            if (expandoDict.ContainsKey(propertyName))
+                expandoDict[propertyName] = propertyValue;
+            else
+                expandoDict.Add(propertyName, propertyValue);
+        }
+    }
+}

--- a/NCS.DSS.Collections/Cosmos/Helper/IDynamicHelper.cs
+++ b/NCS.DSS.Collections/Cosmos/Helper/IDynamicHelper.cs
@@ -1,0 +1,10 @@
+﻿using System.Dynamic;
+
+namespace NCS.DSS.Collections.Cosmos.Helper
+{
+    public interface IDynamicHelper
+    {
+        public void AddProperty(ExpandoObject expando, string propertyName, object propertyValue);
+        public ExpandoObject ExcludeProperty(Exception exception, string[] names);
+    }
+}

--- a/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
+++ b/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
@@ -14,17 +14,15 @@ namespace NCS.DSS.Collections.GetCollectionByIdHttpTrigger.Function
 {
     public class GetCollectionByIdHttpTrigger
     {
-        private readonly IHttpResponseMessageHelper _responseMessageHelper;
-        private IGetCollectionByIdHtppTriggerService _service;
-        private IDssCorrelationValidator _dssCorrelationValidator;
-        private IDssTouchpointValidator _dssTouchpointValidator;
-        private ILogger<GetCollectionByIdHttpTrigger> _logger;
+        private readonly IGetCollectionByIdHtppTriggerService _service;
+        private readonly IDssCorrelationValidator _dssCorrelationValidator;
+        private readonly IDssTouchpointValidator _dssTouchpointValidator;
+        private readonly ILogger<GetCollectionByIdHttpTrigger> _logger;
 
-        public GetCollectionByIdHttpTrigger(IGetCollectionByIdHtppTriggerService service, IHttpResponseMessageHelper responseMessageHelper, ILogger<GetCollectionByIdHttpTrigger> logger, IDssCorrelationValidator dssCorrelationValidator,
+        public GetCollectionByIdHttpTrigger(IGetCollectionByIdHtppTriggerService service, ILogger<GetCollectionByIdHttpTrigger> logger, IDssCorrelationValidator dssCorrelationValidator,
           IDssTouchpointValidator dssTouchpointValidator)
         {
             _service = service;
-            _responseMessageHelper = responseMessageHelper;
             _logger = logger;
             _dssCorrelationValidator = dssCorrelationValidator;
             _dssTouchpointValidator = dssTouchpointValidator;

--- a/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
+++ b/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
@@ -86,11 +86,14 @@ namespace NCS.DSS.Collections.GetCollectionByIdHttpTrigger.Function
 
             var responseObject = new StreamContent(collectionStream);
 
-            return new JsonResult(responseObject, new JsonSerializerOptions())
-            {
-                StatusCode = (int)HttpStatusCode.OK,
-                ContentType = "application/octet-stream",
-            };
+            //return new JsonResult(responseObject., new JsonSerializerOptions())
+            //{
+            //    StatusCode = (int)HttpStatusCode.OK,
+            //    ContentType = "application/octet-stream",
+
+            //};
+
+            return new FileStreamResult(collectionStream, "application/octet-stream");
         }
     }
 }

--- a/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
+++ b/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
@@ -73,26 +73,7 @@ namespace NCS.DSS.Collections.GetCollectionByIdHttpTrigger.Function
 
             collectionStream.Position = 0;
 
-            //var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(collectionStream) };
-            //response.Content.Headers.ContentType.MediaType = "application/octet-stream";
-
-            //var response = new ObjectResult(new StreamContent(collectionStream)) { StatusCode = (int)HttpStatusCode.OK, };
-            //var collection = new Microsoft.AspNetCore.Mvc.Formatters.MediaTypeCollection
-            //{
-            //    new MediaTypeHeaderValue("application/octet-stream")
-            //};
-            //response.ContentTypes = collection;
-            //return response; 
-
             var responseObject = new StreamContent(collectionStream);
-
-            //return new JsonResult(responseObject., new JsonSerializerOptions())
-            //{
-            //    StatusCode = (int)HttpStatusCode.OK,
-            //    ContentType = "application/octet-stream",
-
-            //};
-
             return new FileStreamResult(collectionStream, "application/octet-stream");
         }
     }

--- a/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
+++ b/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
@@ -82,7 +82,7 @@ namespace NCS.DSS.Collections.GetCollectionByIdHttpTrigger.Function
             //    new MediaTypeHeaderValue("application/octet-stream")
             //};
             //response.ContentTypes = collection;
-            //return response;
+            //return response; 
 
             var responseObject = new StreamContent(collectionStream);
 

--- a/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
+++ b/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
@@ -4,12 +4,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
-using Microsoft.Net.Http.Headers;
 using NCS.DSS.Collections.GetCollectionByIdHttpTrigger.Service;
 using NCS.DSS.Collections.Models;
 using NCS.DSS.Collections.Validators;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
+using System.Text.Json;
 
 namespace NCS.DSS.Collections.GetCollectionByIdHttpTrigger.Function
 {
@@ -73,13 +73,24 @@ namespace NCS.DSS.Collections.GetCollectionByIdHttpTrigger.Function
 
             collectionStream.Position = 0;
 
-            var response = new ObjectResult(new StreamContent(collectionStream)) { StatusCode = (int)HttpStatusCode.OK, };
-            var collection = new Microsoft.AspNetCore.Mvc.Formatters.MediaTypeCollection
+            //var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(collectionStream) };
+            //response.Content.Headers.ContentType.MediaType = "application/octet-stream";
+
+            //var response = new ObjectResult(new StreamContent(collectionStream)) { StatusCode = (int)HttpStatusCode.OK, };
+            //var collection = new Microsoft.AspNetCore.Mvc.Formatters.MediaTypeCollection
+            //{
+            //    new MediaTypeHeaderValue("application/octet-stream")
+            //};
+            //response.ContentTypes = collection;
+            //return response;
+
+            var responseObject = new StreamContent(collectionStream);
+
+            return new JsonResult(responseObject, new JsonSerializerOptions())
             {
-                new MediaTypeHeaderValue("application/octet-stream")
+                StatusCode = (int)HttpStatusCode.OK,
+                ContentType = "application/octet-stream",
             };
-            response.ContentTypes = collection;
-            return response;
         }
     }
 }

--- a/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
+++ b/NCS.DSS.Collections/GetCollectionByIdHttpTrigger/Function/GetCollectionByIdHttpTrigger.cs
@@ -9,7 +9,6 @@ using NCS.DSS.Collections.Models;
 using NCS.DSS.Collections.Validators;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
-using System.Text.Json;
 
 namespace NCS.DSS.Collections.GetCollectionByIdHttpTrigger.Function
 {

--- a/NCS.DSS.Collections/GetCollectionsHttpTrigger/Function/GetCollectionsHttpTrigger.cs
+++ b/NCS.DSS.Collections/GetCollectionsHttpTrigger/Function/GetCollectionsHttpTrigger.cs
@@ -1,4 +1,3 @@
-using DFC.HTTP.Standard;
 using DFC.Swagger.Standard.Annotations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -15,17 +14,15 @@ namespace NCS.DSS.Collections.GetCollectionsHttpTrigger.Function
 {
     public class GetCollectionsHttpTrigger
     {
-        private readonly IHttpResponseMessageHelper _responseMessageHelper;
-        private IGetCollectionsHttpTriggerService _service;
-        private IDssCorrelationValidator _dssCorrelationValidator;
-        private IDssTouchpointValidator _dssTouchpointValidator;
-        private ILogger<GetCollectionsHttpTrigger> _logger;
+        private readonly IGetCollectionsHttpTriggerService _service;
+        private readonly IDssCorrelationValidator _dssCorrelationValidator;
+        private readonly IDssTouchpointValidator _dssTouchpointValidator;
+        private readonly ILogger<GetCollectionsHttpTrigger> _logger;
 
-        public GetCollectionsHttpTrigger(IGetCollectionsHttpTriggerService service, IHttpResponseMessageHelper responseMessageHelper, ILogger<GetCollectionsHttpTrigger> logger, IDssCorrelationValidator dssCorrelationValidator,
+        public GetCollectionsHttpTrigger(IGetCollectionsHttpTriggerService service, ILogger<GetCollectionsHttpTrigger> logger, IDssCorrelationValidator dssCorrelationValidator,
           IDssTouchpointValidator dssTouchpointValidator)
         {
             _service = service;
-            _responseMessageHelper = responseMessageHelper;
             _logger = logger;
             _dssCorrelationValidator = dssCorrelationValidator;
             _dssTouchpointValidator = dssTouchpointValidator;

--- a/NCS.DSS.Collections/ServiceBus/DataCollections/Processor/Function/DataCollectionsQueueProcessor.cs
+++ b/NCS.DSS.Collections/ServiceBus/DataCollections/Processor/Function/DataCollectionsQueueProcessor.cs
@@ -1,4 +1,3 @@
-using DFC.Common.Standard.Logging;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using NCS.DSS.Collections.ServiceBus.DataCollections.Messages;

--- a/NCS.DSS.Collections/ServiceBus/DataCollections/Processor/Function/DataCollectionsQueueProcessor.cs
+++ b/NCS.DSS.Collections/ServiceBus/DataCollections/Processor/Function/DataCollectionsQueueProcessor.cs
@@ -11,44 +11,39 @@ namespace NCS.DSS.Collections.ServiceBus.DataCollections.Processor.Function
         private const string _dataCollectionsQueueName = "%DCQueueName_In%";
         private const string _dataCollectionsConnectionString = "ServiceBusConnectionString";
         private IDataCollectionsQueueProcessorService _dataCollectionsQueueProcessorService;
-        private ILoggerHelper _loggerHelper;
+        private ILogger log;
 
-        public DataCollectionsQueueProcessor(IDataCollectionsQueueProcessorService dataCollectionsQueueProcessorService, ILoggerHelper loggerHelper)
+        public DataCollectionsQueueProcessor(IDataCollectionsQueueProcessorService dataCollectionsQueueProcessorService, ILogger<DataCollectionsQueueProcessor> log)
         {
             _dataCollectionsQueueProcessorService = dataCollectionsQueueProcessorService;
-            _loggerHelper = loggerHelper;
+            this.log = log;
         }
 
-
         [Function("DataCollectionsQueueProcessor")]
-        public async Task RunAsync([ServiceBusTrigger(_dataCollectionsQueueName,
-                                                Connection = _dataCollectionsConnectionString)]
-            MessageCrossLoadToNCSDto message,
-                                                ILogger log)
+        public async Task RunAsync([ServiceBusTrigger(_dataCollectionsQueueName, Connection = _dataCollectionsConnectionString)] MessageCrossLoadToNCSDto message)
         {
-            _loggerHelper.LogMethodEnter(log);
-
+            log.LogInformation($"Function {nameof(DataCollectionsQueueProcessor)} has been invoked");
             var correlationId = Guid.NewGuid();
 
             try
             {
                 if (message == null)
                 {
-                    _loggerHelper.LogError(log, correlationId, new NullReferenceException("Message cannot be null"));
+                    log.LogError($"Message cannot be null. Correlation ID: {correlationId}");
                     return;
                 }
 
-                _loggerHelper.LogInformationMessage(log, correlationId, "Attempting to process message");
+                log.LogInformation($"Attempting to process queue message");
                 await _dataCollectionsQueueProcessorService.ProcessMessageAsync(message, log);
             }
             catch (Exception ex)
             {
-                _loggerHelper.LogException(log, correlationId, ex);
+                log.LogError($"An exception has occurred. Correlation ID: {correlationId}", ex);
                 throw;
             }
             finally
             {
-                _loggerHelper.LogMethodExit(log);
+                log.LogInformation($"Function {nameof(DataCollectionsQueueProcessor)} has finished invocation");
             }
         }
     }


### PR DESCRIPTION
**ADO ticket**: https://sfa-gov-uk.visualstudio.com/National%20Careers%20Service%20(NCS)/_workitems/edit/202827

**Associated PRs**:
- https://github.com/SkillsFundingAgency/dss-outcomes/pull/72

**File changes**:
| File name(s) | Change made |
| -- | -- |
| `GetCollectionByIdHttpTrigger.cs` | Replacing return method (`406` is not an acceptable status code - instead it should be a `200`) |
| `DataCollectionsQueueProcessor.cs` | Due to .NET 8, logging should be declared and setup in the constructor of the class instead. Passing into the method as a param is no longer supported. |
| `IDynamicHelper.cs` , `DynamicHelper.cs` | Added helper class to remove object from error message object that isn't handled by the new .NET 8.0 HTTP response object types. |
| `PostCollectionHttpTrigger.cs`, `PostCollectionHttpTriggerServiceTests.cs` | Implemented DynamicHelper in the POST trigger and update unit test. |
| `GetCollectionByIdHttpTrigger.cs`, `GetCollectionsHttpTrigger.cs` | Code clean up. |